### PR TITLE
Geschwindigkeit in EEPROM ALTA DU HÄCKA

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -6,6 +6,7 @@
 // Libraries:
 #include <Arduino.h>
 #include <Stepper.h>
+#include <EEPROM.h>
 
 // Deklarierungen:
 const int SPU = 360;
@@ -48,6 +49,7 @@ void getSpeed(){
         if(change){
           if(velo < 10){
           velo++;
+          EEPROM.write(0, velo);
           } else {
             Serial.println("Reached Maximum!");
           }
@@ -62,6 +64,7 @@ void getSpeed(){
         if(change){
           if(velo > 1){
           velo--;
+          EEPROM.write(0, velo);
           } else {
             Serial.println("Reached Minimum!");
           }
@@ -148,7 +151,8 @@ void setup() {
   digitalWrite(SW_pin, HIGH);
   Serial.println("Started!");
   menu();
-  }
+  velo = EEPROM.read(0);
+}
 
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -151,7 +151,10 @@ void setup() {
   digitalWrite(SW_pin, HIGH);
   Serial.println("Started!");
   menu();
-  velo = EEPROM.read(0);
+  int veloEEPROM = EEPROM.read(0);
+  if(veloEEPROM != 0){
+      velo = veloEEPROM;
+  }
 }
 
 


### PR DESCRIPTION
Geschwindigkeit wird im permanenten Speicher (EEPROM) gesichert und beim start ausgelesen.

